### PR TITLE
Shared emulator library and extern "C"

### DIFF
--- a/stm32/cores/arduelli/wiring_digital.h
+++ b/stm32/cores/arduelli/wiring_digital.h
@@ -33,17 +33,19 @@
 
 #include "wiring_digital_pinMode.h"
 
-static inline
-int digitalRead(pin_t pin) {
+extern "C" {
+ int digitalRead(pin_t pin) {
     return GPIOPIN[pin].gpio_port->IDR & GPIOPIN[pin].gpio_mask? 1: 0;
 }
+}
 
-static inline
-void  digitalWrite(pin_t pin, uint32_t val) {
+extern "C" {
+   void  digitalWrite(pin_t pin, uint32_t val) {
     if (val)
         GPIOPIN[pin].gpio_port->BSRR = GPIOPIN[pin].gpio_mask;
     else
         GPIOPIN[pin].gpio_port->BRR  = GPIOPIN[pin].gpio_mask;
+}
 }
 
 #endif//_WIRING_DIGITAL_H_

--- a/stm32/cores/arduelli/wiring_digital_pinMode.h
+++ b/stm32/cores/arduelli/wiring_digital_pinMode.h
@@ -90,8 +90,13 @@
  *
  * With GCC, generates fair but not optimal code.
  */
-static inline
-void pinMode(pin_t pin, const enum pin_mode mode) {
+/*
+#ifdef __cplusplus
+extern "C"
+#endif
+*/
+extern "C" {
+	void pinMode(pin_t pin, const enum pin_mode mode) {
 
     const uint32_t pin_shift = (GPIOPIN[pin].gpio_pin * 2);
 
@@ -136,5 +141,5 @@ void pinMode(pin_t pin, const enum pin_mode mode) {
         GPIOPIN[pin].gpio_port->MODER &= ~(GPIO_MODER_MODER0 << pin_shift);
     }
 }
-
+}
 #endif

--- a/stm32/make/app.mk
+++ b/stm32/make/app.mk
@@ -39,7 +39,7 @@ APP_OBJS ?= main.o $(APP).o $(VARIANT).o
 
 VPATH += $(TOP)cores/arduelli $(TOP)variants/$(VARIANT)
 
-all:  $(APP) $(APP).hex
+all:  $(APP) $(APP).hex libemulator.so
 
 clean::
 	rm -f $(APP)
@@ -61,3 +61,6 @@ $(APP):	$(APP_OBJS) $(SYSTEM_LIBS) $(PRE_OBJS) $(POST_OBJS)
 
 %.hex:	%
 	$(ELF2HEX) $(EHFLAGS) $< $@
+
+libemulator.so: $(SYSTEM_LIBS) $(PRE_OBJS) $(POST_OBJS)
+	$(LD) $(LDFLAGS) $(SHAREDFLAGS) -o $@ $(PRE_OBJS) $(APP_OBJS) $(LIBS) $(POST_OBJS)

--- a/stm32/make/emulator.mk
+++ b/stm32/make/emulator.mk
@@ -44,10 +44,10 @@ AR  := ar
 ELF2HEX := :
 
 CFLAGS   := \
-  $(subst -std=c99,-std=c++98,$(subst -mcpu=cortex-m0,,$(call expand,compiler.cmd.cc.flags)))
+  $(subst -std=c99,-std=c++11,$(subst -mcpu=cortex-m0,,$(call expand,compiler.cmd.cc.flags)))
 
 CXXFLAGS := \
-  $(subst -std=gnu++0x,-std=c++98,$(subst -mcpu=cortex-m0,,$(call expand,compiler.cmd.cxx.flags)))
+  $(subst -std=gnu++0x,-std=c++11,$(subst -mcpu=cortex-m0,,$(call expand,compiler.cmd.cxx.flags)))
 
 LDFLAGS  := -m32 -demangle -march=i386 $(LD_SCRIPT)
 ARFLAGS  := $(call expand,compiler.cmd.ar.flags)
@@ -62,8 +62,11 @@ CXXFLAGS += $(EXTRA_CFLAGS)
 #
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
-PRE_OBJS  := emulator_pre.o
-POST_OBJS := emulator_post.o
+PRE_OBJS    := emulator_pre.o
+POST_OBJS   := emulator_post.o
+SHAREDFLAGS := -dylib
+else
+SHAREDFLAGS := -shared -Xlinker --export-dynamic
 endif
 
 #
@@ -78,3 +81,9 @@ LIBS += -lstdc++
 
 SYSTEM_OBJS := emulator.o Register.o RCC.o FLASH.o GPIO.o TIM.o USART.o SPI.o
 VPATH += $(TOP)emulator/src
+
+#
+# Emulator shared library
+#
+libemulator.so: $(SYSTEM_LIBS) $(PRE_OBJS) $(POST_OBJS)
+	$(LD) $(LDFLAGS) $(SHAREDFLAGS) -o $@ $(PRE_OBJS) $(APP_OBJS) $(LIBS) $(POST_OBJS)

--- a/stm32/tests/test_SPI_begin/test_SPI_begin.cpp
+++ b/stm32/tests/test_SPI_begin/test_SPI_begin.cpp
@@ -27,6 +27,6 @@ void setup() {
 
 void loop() {
 #ifdef EMULATOR
-    _exit(0);
+    exit(0);
 #endif
 }

--- a/stm32/tests/test_Serial_begin/test_Serial_begin.cpp
+++ b/stm32/tests/test_Serial_begin/test_Serial_begin.cpp
@@ -25,6 +25,6 @@ void setup() {
 
 void loop() {
 #ifdef EMULATOR
-    _exit(0);
+    exit(0);
 #endif
 }

--- a/stm32/tests/test_Serial_write_uint8/test_Serial_write_uint8.cpp
+++ b/stm32/tests/test_Serial_write_uint8/test_Serial_write_uint8.cpp
@@ -31,6 +31,6 @@ void setup() {
 
 void loop() {
 #ifdef EMULATOR
-    _exit(0);
+    exit(0);
 #endif
 }

--- a/stm32/tests/test_analogWrite/test_analogWrite.cpp
+++ b/stm32/tests/test_analogWrite/test_analogWrite.cpp
@@ -27,6 +27,6 @@ void setup() {
 
 void loop() {
 #ifdef EMULATOR
-    _exit(0);
+    exit(0);
 #endif
 }

--- a/stm32/tests/test_digitalRead/test_digitalRead.cpp
+++ b/stm32/tests/test_digitalRead/test_digitalRead.cpp
@@ -26,6 +26,6 @@ void setup() {
 
 void loop() {
 #ifdef EMULATOR
-    _exit(0);
+    exit(0);
 #endif
 }

--- a/stm32/tests/test_digitalWrite/test_digitalWrite.cpp
+++ b/stm32/tests/test_digitalWrite/test_digitalWrite.cpp
@@ -27,6 +27,6 @@ void setup() {
 
 void loop() {
 #ifdef EMULATOR
-    _exit(0);
+    exit(0);
 #endif
 }

--- a/stm32/tests/test_pinMode/test_pinMode.cpp
+++ b/stm32/tests/test_pinMode/test_pinMode.cpp
@@ -29,6 +29,6 @@ void setup() {
 
 void loop() {
 #ifdef EMULATOR
-    _exit(0);
+    exit(0);
 #endif
 }


### PR DESCRIPTION
Runtime/stm32/make/app.mk
Runtime/stm32/make/emulator.mk 
The emulator shared dynamic library can be made with changes to the files. But, the libemulator.so is also building and copied in other folders e.g. .../tests other then .../build folder.

Runtime/stm32/cores/wiring_digital.h
Runtime/stm32/cores/wiring_digital_pinmode.h
The extern "C" wrapper is added to the functions written in C++ in above files, so that the functions can be called from ctypes module in Python.
