### PR TITLE
Remove unnecessary stack pointer initialisation

### DIFF
--- a/stm32/system/stm32/src/startup_stm32f334xx.c
+++ b/stm32/system/stm32/src/startup_stm32f334xx.c
@@ -278,14 +278,6 @@ extern uint32_t _sidata, _sdata, _edata, _sbss, _ebss;
  * Reset handler
  */
 void Reset_Handler(void) {
-#ifndef EMULATOR
-    /* XXX: I'm not sure if this stack initialisation is *really*
-     *      needed.  According to ARM documentation the CPU should
-     *      do it itself.
-     */
-    register void *const stack = &_estack;
-    __asm__ volatile ("mov    sp, %0" : : "r" (stack));
-#endif
 
     /* Copy initialised non-const data from flash to RAM */
     register uint32_t *flash = &_sidata;

--- a/stm32/system/stm32/src/startup_stm32f40xx.c
+++ b/stm32/system/stm32/src/startup_stm32f40xx.c
@@ -314,14 +314,6 @@ extern uint32_t _sidata, _sdata, _edata, _sbss, _ebss;
  * Reset handler
  */
 void Reset_Handler(void) {
-#ifndef EMULATOR
-    /* XXX: I'm not sure if this stack initialisation is *really*
-     *      needed.  According to ARM documentation the CPU should
-     *      do it itself.
-     */
-    register void *const stack = &_estack;
-    __asm__ volatile ("mov    sp, %0" : : "r" (stack));
-#endif
 
     /* Copy initialised non-const data from flash to RAM */
     register uint32_t *flash = &_sidata;


### PR DESCRIPTION
Hi, I already tested that this section of code is unnecessary. However, I still haven't checked for the stm32f0 family, although it should be also unnecessary in theory.
