### PR TITLE
Fix for keeping FLASH_BASE undefined on Emulator

### DIFF
--- a/stm32/emulator/inc/stm32fxxx.h
+++ b/stm32/emulator/inc/stm32fxxx.h
@@ -29,10 +29,7 @@ typedef Register preg16_t;
  * Undefine the main address defines in the real stm32f0xx.h, causing
  * a compile error on all constructs that use them.
  */
-/* XXX There is a problem with undefining FLASH_BASE, because it
- * is used by the stm32f4 initialization of the SCB->VTOR
- */
-//#undef FLASH_BASE
+#undef FLASH_BASE
 #undef SRAM_BASE
 #undef PERIPH_BASE
 

--- a/stm32/system/stm32/src/system_stm32f3xx.c
+++ b/stm32/system/stm32/src/system_stm32f3xx.c
@@ -200,8 +200,6 @@ void SystemInit(void)
 
 #ifdef VECT_TAB_SRAM
   SCB->VTOR = SRAM_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal SRAM */
-#else
-  SCB->VTOR = FLASH_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal FLASH */
 #endif
 }
 

--- a/stm32/system/stm32/src/system_stm32f4xx.c
+++ b/stm32/system/stm32/src/system_stm32f4xx.c
@@ -370,8 +370,6 @@ void SystemInit(void)
   /* Configure the Vector Table location add offset address ------------------*/
 #ifdef VECT_TAB_SRAM
   SCB->VTOR = SRAM_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal SRAM */
-#else
-  SCB->VTOR = FLASH_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal FLASH */
 #endif
 }
 


### PR DESCRIPTION
I already tested the change. There is no change in behaviour as the flash is also mapped to the 0 address on both platforms (stm32f4 and stm32f334). That is the very reason the system actually works and boots.
